### PR TITLE
Init RISCV64 toolchain build

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ Along with the Server SoC Spec, there is a test spec which defines a set of test
 4.  git apply ShellPkg/Application/server-soc-ts/patches/edk2-stable202302-server-soc-ts-acpi.diff 
 
 ### 3. Build the TestSuite under UEFI
-1.  export GCC49\_AARCH64\_PREFIX= GCC10.3 toolchain path pointing to **/bin/aarch64-linux-gnu-** in case of x86 machine.
+1.  export GCC5\_RISCV64\_PREFIX= GCC10.3 toolchain path pointing to **/bin/riscv64-linux-gnu-** in case of x86 machine.
 2.  export PACKAGES\_PATH= path pointing to edk2-libc
 3.  source edksetup.sh
 4.  make -C BaseTools/Source/C
 5.  source ShellPkg/Application/server-soc-ts/tools/scripts/acsbuild.sh
 
-The EFI executable file is generated at <edk2_path>/Build/Shell/DEBUG\_GCC49/AARCH64/Bsa.efi
+The EFI executable file is generated at <edk2_path>/Build/Shell/DEBUG\_GCC5/RISCV64/Bsa.efi
 
 -------------------------
 Following are the original content of BSA ACS need to be updated. 

--- a/patches/edk2-stable202302-server-soc-ts-acpi.diff
+++ b/patches/edk2-stable202302-server-soc-ts-acpi.diff
@@ -1,5 +1,25 @@
+diff --git a/MdePkg/Include/RiscV64/ProcessorBind.h b/MdePkg/Include/RiscV64/ProcessorBind.h
+index 1d42d92..87c956a 100644
+--- a/MdePkg/Include/RiscV64/ProcessorBind.h
++++ b/MdePkg/Include/RiscV64/ProcessorBind.h
+@@ -152,6 +152,15 @@ typedef INT64 INTN __attribute__ ((aligned (8)));
+ /// Define this macro to unify the usage.
+ ///
+ #define ASM_GLOBAL  .globl
++
++#define GCC_ASM_EXPORT(func__)  \
++         .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)    ;\
++         .type ASM_PFX(func__), %function
++
++#define GCC_ASM_IMPORT(func__)  \
++         .extern  _CONCATENATE (__USER_LABEL_PREFIX__, func__)
++
++
+ #endif
+ 
+ /**
 diff --git a/ShellPkg/ShellPkg.dsc b/ShellPkg/ShellPkg.dsc
-index dd0d88603f..be93c3de1d 100644
+index dd0d886..be93c3d 100644
 --- a/ShellPkg/ShellPkg.dsc
 +++ b/ShellPkg/ShellPkg.dsc
 @@ -65,6 +65,10 @@

--- a/platform/pal_baremetal/BsaPalBaremetalLib.inf
+++ b/platform/pal_baremetal/BsaPalBaremetalLib.inf
@@ -80,4 +80,4 @@
   gEfiAcpiTableGuid
 
 [BuildOptions]
-  GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
+  GCC:*_*_*_ASM_FLAGS  =  -march=rv64gc

--- a/platform/pal_baremetal/RDN2/BsaPalFVPLib.inf
+++ b/platform/pal_baremetal/RDN2/BsaPalFVPLib.inf
@@ -60,4 +60,4 @@
   gEfiAcpiTableGuid
 
 [BuildOptions]
-  GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
+  GCC:*_*_*_ASM_FLAGS  =  -march=rv64gc

--- a/platform/pal_uefi_acpi/BsaPalLib.inf
+++ b/platform/pal_uefi_acpi/BsaPalLib.inf
@@ -25,9 +25,9 @@
   LIBRARY_CLASS                  = BsaPalLib|UEFI_APPLICATION UEFI_DRIVER
 
 [Sources.common]
-  src/AArch64/ArmSmc.S
-  src/AArch64/AcsTestInfra.S
-  src/AArch64/ModuleEntryPoint.S
+  src/RISCV64/ArmSmc.S
+  src/RISCV64/AcsTestInfra.S
+  src/RISCV64/ModuleEntryPoint.S
   src/pal_misc.c
   src/pal_acpi.c
   src/pal_pe.c
@@ -72,4 +72,4 @@
   gEfiAcpiTableGuid
 
 [BuildOptions]
-  GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
+  GCC:*_*_*_ASM_FLAGS  =  -march=rv64gc

--- a/platform/pal_uefi_acpi/src/RISCV64/AcsTestInfra.S
+++ b/platform/pal_uefi_acpi/src/RISCV64/AcsTestInfra.S
@@ -31,7 +31,12 @@ GCC_ASM_EXPORT(DataCacheCleanVA)
 
 ASM_PFX(DataCacheCleanInvalidateVA):
 #  dc  civac, x0
-   cbo.flush 0(a0)
+#   cbo.flush 0(a0)
+/*
+   templorily comment the cbo instruction until we move to GCC13:
+   https://gcc.gnu.org/gcc-13/changes.html
+   (CMO is supported by gcc-13)
+ */
 #  dsb sy
    fence 
 #  isb
@@ -43,19 +48,29 @@ ASM_PFX(DataCacheCleanInvalidateVA):
   ret
 
 ASM_PFX(DataCacheCleanVA):
-#  dc  cvac, x0
-   cbo.clean 0(a0)
-#  dsb ish
+##  dc  cvac, x0
+#   cbo.clean 0(a0)
+/*
+   templorily comment the cbo instruction until we move to GCC13:
+   https://gcc.gnu.org/gcc-13/changes.html
+   (CMO is supported by gcc-13)
+ */
+##  dsb ish
    fence 
-#  isb
+##  isb
    fence.i
   ret
 
 ASM_PFX(DataCacheInvalidateVA):
-#  dc  ivac, x0
-   cbo.inval 0(a0)
-#  dsb ish
+##  dc  ivac, x0
+#   cbo.inval 0(a0)
+/*
+   templorily comment the cbo instruction until we move to GCC13:
+   https://gcc.gnu.org/gcc-13/changes.html
+   (CMO is supported by gcc-13)
+ */
+##  dsb ish
    fence
-#  isb
+##  isb
    fence.i
   ret

--- a/platform/pal_uefi_acpi/src/RISCV64/ArmSmc.S
+++ b/platform/pal_uefi_acpi/src/RISCV64/ArmSmc.S
@@ -1,0 +1,71 @@
+#/** @file
+# Copyright (c) 2016-2018, 2023, Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#**/
+
+.text
+.align 3
+
+GCC_ASM_IMPORT(gPsciConduit)
+.equ CONDUIT_SMC,        0
+.equ CONDUIT_HVC,        1
+.equ INVALID_PARAMETER, -3
+
+GCC_ASM_EXPORT(ArmCallSmc)
+
+ASM_PFX(ArmCallSmc):
+#  // Push x0 on the stack - The stack must always be quad-word aligned
+#  str   x0, [sp, #-16]!
+#
+#  // Load the conduit into x10
+#  mov   x10, x1
+#
+#  // Load the SMC arguments values into the appropriate registers
+#  ldp   x6, x7, [x0, #48]
+#  ldp   x4, x5, [x0, #32]
+#  ldp   x2, x3, [x0, #16]
+#  ldp   x0, x1, [x0, #0]
+#
+#  // Check whether the conduit is SMC or HVC
+#  cmp   x10, CONDUIT_SMC
+#  beq   conduit_smc
+#  cmp   x10, CONDUIT_HVC
+#  beq   conduit_hvc
+#
+#conduit_invalid:
+#  mov   x0, INVALID_PARAMETER
+#  b     finish
+#
+#conduit_smc:
+#  smc   #0
+#  b     finish
+#
+#conduit_hvc:
+#  hvc   #0
+#  b     finish
+#
+#finish:
+#  // Pop the ARM_SMC_ARGS structure address from the stack into x9
+#  ldr   x9, [sp], #16
+#
+#  // Store the SMC returned values into the ARM_SMC_ARGS structure.
+#  // A SMC call can return up to 4 values - we do not need to store back x4-x7.
+#  stp   x2, x3, [x9, #16]
+#  stp   x0, x1, [x9, #0]
+#
+#  mov   x0, x9
+#
+  ret

--- a/platform/pal_uefi_acpi/src/RISCV64/ModuleEntryPoint.S
+++ b/platform/pal_uefi_acpi/src/RISCV64/ModuleEntryPoint.S
@@ -1,0 +1,83 @@
+#/** @file
+# Copyright (c) 2016-2018, Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#**/
+
+.text
+.align 3
+
+GCC_ASM_IMPORT(ArmReadMpidr)
+GCC_ASM_IMPORT(PalGetSecondaryStackBase)
+GCC_ASM_IMPORT(PalGetMaxMpidr)
+GCC_ASM_EXPORT(ModuleEntryPoint)
+
+StartupAddr:         .8byte ASM_PFX(val_test_entry)
+ASM_PFX(StackSize):  .8byte 0x100
+
+ASM_PFX(ModuleEntryPoint):
+#  // Get ID of this CPU in Multicore system
+#  bl    ASM_PFX(ArmReadMpidr)
+#  // Keep a copy of the MpId register value
+#  mov   x10, x0
+#
+#  // With this function: CorePos = (Aff3 x maxAff2 x maxAff1 x maxAff0) +
+#  //                                 (Aff2 x maxAff1 x maxAff0) + (Aff1 x maxAff0) + Aff0
+#  and   x1, x0, 0xFF
+#  and   x2, x0, 0xFF00
+#  lsr   x2, x2, 8
+#  and   x3, x0, 0xFF0000
+#  lsr   x3, x3, 16
+#  and   x4, x0, 0xFF00000000
+#  lsr   x4, x4, 32
+#
+#  bl    ASM_PFX(PalGetMaxMpidr)
+#  and   x5, x0, 0xFF
+#  add   x5, x5, 1
+#  and   x6, x0, 0xFF00
+#  lsr   x6, x6, 8
+#  add   x6, x6, 1
+#  and   x7, x0, 0xFF0000
+#  lsr   x7, x7, 16
+#  add   x7, x7, 1
+#  and   x8, x0, 0xFF00000000
+#  lsr   x8, x8, 32
+#  add   x8, x8, 1    // x8 has maxAff3, which is reserved for future use
+#
+#  madd  x0, x2, x5, x1
+#  mul   x5, x5, x6
+#  madd  x0, x3, x5, x0
+#  mul   x5, x5, x7
+#  madd  x0, x4, x5, x0
+#
+#  ldr   x3, StackSize
+#  mul   x3, x3, x0
+#_GetStackBase:
+#  mov   x0, 0
+#  //ldr   x4, GetStackMem
+#  //blr   x4
+#  //ASM_PFX(pal_allocate_stack)
+#  bl ASM_PFX(PalGetSecondaryStackBase)
+#  add   x0, x0, x3
+#  mov   sp, x0
+#_PrepareArguments:
+#
+#  ldr   x4, StartupAddr
+#
+#  blr   x4
+#
+#_NeverReturn:
+#  b _NeverReturn
+#

--- a/platform/pal_uefi_dt/BsaPalLib.inf
+++ b/platform/pal_uefi_dt/BsaPalLib.inf
@@ -75,4 +75,4 @@
   gFdtTableGuid
 
 [BuildOptions]
-  GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
+  GCC:*_*_*_ASM_FLAGS  =  -march=rv64gc

--- a/tools/scripts/acsbuild.sh
+++ b/tools/scripts/acsbuild.sh
@@ -1,4 +1,4 @@
-if [ $(uname -m) != "aarch64" ] && [ -v $GCC49_AARCH64_PREFIX ]
+if [ $(uname -m) != "aarch64" ] && [ -v $GCC5_RISCV64_PREFIX ]
 then
     echo "GCC49_AARCH64_PREFIX is not set"
     echo "set using export GCC49_AARCH64_PREFIX=<lib_path>/bin/aarch64-linux-gnu-"
@@ -6,8 +6,8 @@ then
 fi
 
 if [ "$1" == "ENABLE_OOB" ]; then
-    build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/server-soc-ts/baremetal_app/BsaAcs.inf -D ENABLE_OOB
+    build -a RISCV64 -t GCC5 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/server-soc-ts/baremetal_app/BsaAcs.inf -D ENABLE_OOB
     return 0;
 fi
 
-    build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/server-soc-ts/uefi_app/BsaAcs.inf
+    build -a RISCV64 -t GCC5 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/server-soc-ts/uefi_app/BsaAcs.inf

--- a/uefi_app/BsaAcs.inf
+++ b/uefi_app/BsaAcs.inf
@@ -134,6 +134,112 @@
   # ../test_pool/exerciser/operating_system/test_os_e015.c
   # ../test_pool/exerciser/operating_system/test_os_e016.c
   # ../test_pool/exerciser/operating_system/test_os_e017.c
+[Sources.RISCV64]
+  ../
+  BsaAcsMain.c
+  ../test_pool/pe/operating_system/test_os_c001.c
+  # ../test_pool/pe/operating_system/test_os_c002.c
+  # ../test_pool/pe/operating_system/test_os_c003.c
+  # ../test_pool/pe/operating_system/test_os_c004.c
+  # ../test_pool/pe/operating_system/test_os_c006.c
+  # ../test_pool/pe/operating_system/test_os_c007.c
+  # ../test_pool/pe/operating_system/test_os_c008.c
+  # ../test_pool/pe/operating_system/test_os_c009.c
+  # ../test_pool/pe/operating_system/test_os_c010.c
+  # ../test_pool/pe/operating_system/test_os_c011.c
+  # ../test_pool/pe/operating_system/test_os_c012.c
+  # ../test_pool/pe/operating_system/test_os_c013.c
+  # ../test_pool/pe/operating_system/test_os_c014.c
+  # ../test_pool/pe/hypervisor/test_hyp_c001.c
+  # ../test_pool/pe/hypervisor/test_hyp_c002.c
+  # ../test_pool/pe/hypervisor/test_hyp_c003.c
+  # ../test_pool/pe/hypervisor/test_hyp_c004.c
+  # ../test_pool/pe/hypervisor/test_hyp_c005.c
+  # ../test_pool/pe/platform_security/test_ps_c001.c
+  # ../test_pool/memory_map/operating_system/test_os_m001.c
+  # ../test_pool/memory_map/operating_system/test_os_m002.c
+  # ../test_pool/memory_map/operating_system/test_os_m003.c
+  # ../test_pool/gic/operating_system/test_os_g001.c
+  # ../test_pool/gic/operating_system/test_os_g002.c
+  # ../test_pool/gic/operating_system/test_os_g003.c
+  # ../test_pool/gic/operating_system/test_os_g004.c
+  # ../test_pool/gic/operating_system/test_os_g005.c
+  # ../test_pool/gic/operating_system/test_os_g006.c
+  # ../test_pool/gic/operating_system/test_os_g007.c
+  # ../test_pool/gic/operating_system/test_os_v2m001.c
+  # ../test_pool/gic/operating_system/test_os_v2m002.c
+  # ../test_pool/gic/operating_system/test_os_v2m003.c
+  # ../test_pool/gic/operating_system/test_os_v2m004.c
+  # ../test_pool/gic/operating_system/test_os_its001.c
+  # ../test_pool/gic/operating_system/test_os_its002.c
+  # ../test_pool/gic/operating_system/test_os_its003.c
+  # ../test_pool/gic/operating_system/test_os_its004.c
+  # ../test_pool/gic/hypervisor/test_hyp_g001.c
+  # ../test_pool/gic/hypervisor/test_hyp_g002.c
+  # ../test_pool/gic/hypervisor/test_hyp_g003.c
+  ../test_pool/timer/operating_system/test_os_t001.c
+  ../test_pool/timer/operating_system/test_os_t002.c
+  ../test_pool/timer/operating_system/test_os_t003.c
+  ../test_pool/timer/operating_system/test_os_t004.c
+  ../test_pool/timer/operating_system/test_os_t005.c
+  # ../test_pool/watchdog/operating_system/test_os_w001.c
+  # ../test_pool/watchdog/operating_system/test_os_w002.c
+  # ../test_pool/pcie/operating_system/test_os_p001.c
+  # ../test_pool/pcie/operating_system/test_os_p002.c
+  # ../test_pool/pcie/operating_system/test_os_p003.c
+  # ../test_pool/pcie/operating_system/test_os_p006.c
+  # ../test_pool/pcie/operating_system/test_os_p008.c
+  # ../test_pool/pcie/operating_system/test_os_p009.c
+  # ../test_pool/pcie/operating_system/test_os_p011.c
+  # ../test_pool/pcie/operating_system/test_os_p017.c
+  # ../test_pool/pcie/operating_system/test_os_p018.c
+  # ../test_pool/pcie/operating_system/test_os_p019.c
+  # ../test_pool/pcie/operating_system/test_os_p020.c
+  # ../test_pool/pcie/operating_system/test_os_p021.c
+  # ../test_pool/pcie/operating_system/test_os_p022.c
+  # ../test_pool/pcie/operating_system/test_os_p024.c
+  # ../test_pool/pcie/operating_system/test_os_p025.c
+  # ../test_pool/pcie/operating_system/test_os_p026.c
+  # ../test_pool/pcie/operating_system/test_os_p030.c
+  # ../test_pool/pcie/operating_system/test_os_p031.c
+  # ../test_pool/pcie/operating_system/test_os_p032.c
+  # ../test_pool/pcie/operating_system/test_os_p033.c
+  # ../test_pool/pcie/operating_system/test_os_p035.c
+  # ../test_pool/pcie/operating_system/test_os_p036.c
+  # ../test_pool/pcie/operating_system/test_os_p037.c
+  # ../test_pool/pcie/operating_system/test_os_p038.c
+  # ../test_pool/pcie/operating_system/test_os_p039.c
+  # ../test_pool/pcie/operating_system/test_os_p040.c
+  # ../test_pool/pcie/operating_system/test_os_p042.c
+  # ../test_pool/smmu/operating_system/test_os_i001.c
+  # ../test_pool/smmu/operating_system/test_os_i002.c
+  # ../test_pool/smmu/operating_system/test_os_i003.c
+  # ../test_pool/smmu/operating_system/test_os_i004.c
+  # ../test_pool/smmu/hypervisor/test_hyp_i002.c
+  # ../test_pool/smmu/hypervisor/test_hyp_i003.c
+  # ../test_pool/smmu/hypervisor/test_hyp_i004.c
+  # ../test_pool/power_wakeup/operating_system/test_os_u001.c
+  # ../test_pool/power_wakeup/operating_system/test_os_u002.c
+  # ../test_pool/peripherals/operating_system/test_os_d001.c
+  # ../test_pool/peripherals/operating_system/test_os_d002.c
+  # ../test_pool/peripherals/operating_system/test_os_d003.c
+  # ../test_pool/peripherals/operating_system/test_os_d005.c
+  # ../test_pool/exerciser/operating_system/test_os_e001.c
+  # ../test_pool/exerciser/operating_system/test_os_e002.c
+  # ../test_pool/exerciser/operating_system/test_os_e003.c
+  # ../test_pool/exerciser/operating_system/test_os_e004.c
+  # ../test_pool/exerciser/operating_system/test_os_e005.c
+  # ../test_pool/exerciser/operating_system/test_os_e006.c
+  # ../test_pool/exerciser/operating_system/test_os_e007.c
+  # ../test_pool/exerciser/operating_system/test_os_e008.c
+  # ../test_pool/exerciser/operating_system/test_os_e010.c
+  # ../test_pool/exerciser/operating_system/test_os_e011.c
+  # ../test_pool/exerciser/operating_system/test_os_e012.c
+  # ../test_pool/exerciser/operating_system/test_os_e013.c
+  # ../test_pool/exerciser/operating_system/test_os_e014.c
+  # ../test_pool/exerciser/operating_system/test_os_e015.c
+  # ../test_pool/exerciser/operating_system/test_os_e016.c
+  # ../test_pool/exerciser/operating_system/test_os_e017.c
 
 [Packages]
   StdLib/StdLib.dec

--- a/val/BsaValBaremetalLib.inf
+++ b/val/BsaValBaremetalLib.inf
@@ -24,10 +24,10 @@
   LIBRARY_CLASS                  = BsaValLib|UEFI_APPLICATION UEFI_DRIVER
 
 [Sources.common]
-  src/AArch64/PeRegSysSupport.S
-  src/AArch64/PeTestSupport.S
-  src/AArch64/ArchTimerSupport.S
-  src/AArch64/GicSupport.S
+  src/RISCV64/PeRegSysSupport.S
+  src/RISCV64/PeTestSupport.S
+  src/RISCV64/ArchTimerSupport.S
+  src/RISCV64/GicSupport.S
   src/acs_status.c
   src/acs_pe.c
   src/acs_pe_infra.c
@@ -63,4 +63,4 @@
   MdePkg/MdePkg.dec
 
 [BuildOptions]
-  GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
+  GCC:*_*_*_ASM_FLAGS  =  -march=rv64gc

--- a/val/BsaValLib.inf
+++ b/val/BsaValLib.inf
@@ -24,10 +24,10 @@
   LIBRARY_CLASS                  = BsaValLib|UEFI_APPLICATION UEFI_DRIVER
 
 [Sources.common]
-  src/AArch64/PeRegSysSupport.S
-  src/AArch64/PeTestSupport.S
-  src/AArch64/ArchTimerSupport.S
-  src/AArch64/GicSupport.S
+  src/RISCV64/PeRegSysSupport.S
+  src/RISCV64/PeTestSupport.S
+  src/RISCV64/ArchTimerSupport.S
+  src/RISCV64/GicSupport.S
   src/acs_status.c
   src/acs_pe.c
   src/acs_pe_infra.c
@@ -49,10 +49,10 @@
   # sys_arch_src/smmu_v3/smmu_v3.c
   sys_arch_src/gic/gic.c
   sys_arch_src/gic/bsa_exception.c
-  sys_arch_src/gic/AArch64/bsa_exception_asm.S
+  sys_arch_src/gic/RISCV64/bsa_exception_asm.S
   sys_arch_src/gic/v3/gic_v3.c
   sys_arch_src/gic/v3/gic_v3_extended.c
-  sys_arch_src/gic/v3/AArch64/v3_asm.S
+  sys_arch_src/gic/v3/RISCV64/v3_asm.S
   sys_arch_src/gic/v2/gic_v2.c
   # sys_arch_src/pcie/pcie.c
   sys_arch_src/gic/its/bsa_gic_its.c
@@ -62,4 +62,4 @@
   MdePkg/MdePkg.dec
 
 [BuildOptions]
-  GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
+  GCC:*_*_*_ASM_FLAGS  =  -march=rv64gc

--- a/val/src/RISCV64/AcsBootEntry.S
+++ b/val/src/RISCV64/AcsBootEntry.S
@@ -1,0 +1,201 @@
+/** @file
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "BsaAcs.h"
+
+    .extern val_main
+    .extern vector_table
+    .extern val_fixup_symbol_table
+    .extern val_inv_dcache_range
+    .extern val_inv_icache_range
+    .extern g_primary_mpidr
+
+    .cfi_sections .debug_frame
+    .globl    acs_host_entry
+    .section .text.acs_host_entry, "ax"
+
+.macro    dcache_line_size  reg, tmp
+    mrs    \tmp, ctr_el0
+    ubfx    \tmp, \tmp, #16, #4
+    mov    \reg, #4
+    lsl    \reg, \reg, \tmp
+.endm
+
+.macro    icache_line_size  reg, tmp
+    mrs    \tmp, ctr_el0
+    and    \tmp, \tmp, #0xf
+    mov    \reg, #4
+    lsl    \reg, \reg, \tmp
+.endm
+
+.macro do_icache_maintenance_by_mva op
+    /* Exit early if size is zero */
+    cbz    x1, exit_loop_\op
+    icache_line_size x2, x3
+    add    x1, x0, x1
+    sub    x3, x2, #1
+    bic    x0, x0, x3
+loop_\op:
+    ic    \op, x0
+    add    x0, x0, x2
+    cmp    x0, x1
+    b.lo    loop_\op
+    dsb    sy
+exit_loop_\op:
+    ret
+.endm
+
+/*
+ * This macro can be used for implementing various data cache operations `op`
+ */
+.macro do_dcache_maintenance_by_mva op
+    /* Exit early if size is zero */
+    cbz    x1, exit_loop_\op
+    dcache_line_size x2, x3
+    add    x1, x0, x1
+    sub    x3, x2, #1
+    bic    x0, x0, x3
+loop_\op:
+    dc    \op, x0
+    add    x0, x0, x2
+    cmp    x0, x1
+    b.lo    loop_\op
+    dsb    sy
+exit_loop_\op:
+    ret
+.endm
+
+acs_host_entry:
+   /* Install vector table */
+    adr x0, vector_table
+    msr  vbar_el2, x0
+
+   /* Set x19 = 1 for primary cpu
+    * Set x19 = 0 for secondary cpu
+    */
+    adr x18, g_primary_mpidr
+    ldr x0, [x18]
+    mov   x2, #INVALID_MPIDR
+    cmp   x2, x0
+    b.eq  primary_cpu_entry
+
+    mrs x2, mpidr_el1
+    cmp   x2, x0
+    b.ne  secondary_cpu_entry
+
+
+primary_cpu_entry:
+    mov   x19, #1
+
+   /*
+     * Invalidate the instr cache for the code region.
+     * This prevents re-use of stale data cache entries from
+     * prior bootloader stages.
+     */
+    adr x0, __TEXT_START__
+    adr x1, __TEXT_END__
+    sub x1, x1, x0
+    bl  val_inv_icache_range
+
+    /*
+     * Invalidate the data cache for the data regions.
+     * This prevents re-use of stale data cache entries from
+     * prior bootloader stages.
+     */
+    adrp x0, __RODATA_START__
+    add	 x0, x0, :lo12:__RODATA_START__
+    adrp x1, __RODATA_END__
+    add	x1, x1, :lo12:__RODATA_END__
+    sub x1, x1, x0
+    bl  val_inv_dcache_range
+
+
+    /* Enable I-Cache */
+    mrs  x0, sctlr_el2
+    orr  x0, x0, #SCTLR_I_BIT
+    msr  sctlr_el2, x0
+    isb
+
+    /* Save the primary cpu mpidr */
+    adr x18, g_primary_mpidr
+    mrs x0, mpidr_el1
+    str x0, [x18]
+
+   /* Clear BSS */
+  adrp x0, __BSS_START__
+  add  x0,x0,:lo12:__BSS_START__
+  adrp x1, __BSS_END__
+  add  x1,x1,:lo12:__BSS_END__
+  sub x1, x1, x0
+  //bl  val_inv_dcache_range
+
+1:
+   stp xzr, xzr, [x0]
+   add x0, x0, #16
+   sub x1, x1, #16
+   cmp xzr, x1
+   b.ne 1b
+
+   b  0f
+
+secondary_cpu_entry:
+    mov   x19, #0
+
+    /* Enable I-Cache */
+    mrs  x0, sctlr_el2
+    orr  x0, x0, #SCTLR_I_BIT
+    msr  sctlr_el2, x0
+    isb
+
+0:
+   /* Setup the dummy stack to call val_get_pe_id C fn */
+    adrp  x1, dummy_stack_end
+    add x1,x1,#:lo12:dummy_stack_end
+    mov  sp, x1
+
+    mrs  x0, mpidr_el1
+    bl   val_get_pe_id
+
+    /* Now setup the stack pointer with actual stack addr
+     * for the logic cpuid return by val_get_pe_id
+     */
+    adrp  x1, stacks_end
+    add x1,x1,#:lo12:stacks_end
+    mov  x2, #STACK_SIZE
+    mul  x2, x0, x2
+    sub  sp, x1, x2
+
+    /* And jump to the C entrypoint. */
+    mov  x0, x19
+    b    ShellAppMainbsa
+
+val_inv_icache_range:
+    do_icache_maintenance_by_mva ivau
+
+val_inv_dcache_range:
+    do_dcache_maintenance_by_mva ivac
+
+
+.section .bss.stacks
+  .global stacks_start
+  .global stacks_end
+    .balign CACHE_WRITEBACK_GRANULE
+stacks_start:
+    .fill    STACK_SIZE * PLATFORM_CPU_COUNT
+stacks_end:
+    .fill    STACK_SIZE
+dummy_stack_end:

--- a/val/src/RISCV64/ArchTimerSupport.S
+++ b/val/src/RISCV64/ArchTimerSupport.S
@@ -1,0 +1,214 @@
+#/** @file
+# Copyright (c) 2016-2018,2023 Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#**/
+
+
+#ifdef TARGET_EMULATION
+/* Private worker functions for ASM_PFX() */
+#define _CONCATENATE(a, b)  __CONCATENATE(a, b)
+#define __CONCATENATE(a, b) a ## b
+
+/* The __USER_LABEL_PREFIX__ macro predefined by GNUC represents
+   the prefix on symbols in assembly language.*/
+#define __USER_LABEL_PREFIX__
+
+#define ASM_PFX(name) _CONCATENATE (__USER_LABEL_PREFIX__, name)
+
+#define GCC_ASM_EXPORT(func__)  \
+       .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)    ;\
+       .type ASM_PFX(func__), %function
+
+#define GCC_ASM_IMPORT(func__)  \
+       .extern  _CONCATENATE (__USER_LABEL_PREFIX__, func__)
+#endif
+
+.text
+.align 2
+
+GCC_ASM_EXPORT(ArmReadCntFrq)
+GCC_ASM_EXPORT(ArmReadCntPct)
+GCC_ASM_EXPORT(ArmReadCntkCtl)
+GCC_ASM_EXPORT(ArmWriteCntkCtl)
+GCC_ASM_EXPORT(ArmReadCntpTval)
+GCC_ASM_EXPORT(ArmWriteCntpTval)
+GCC_ASM_EXPORT(ArmReadCntpCtl)
+GCC_ASM_EXPORT(ArmWriteCntpCtl)
+GCC_ASM_EXPORT(ArmReadCntvTval)
+GCC_ASM_EXPORT(ArmWriteCntvTval)
+GCC_ASM_EXPORT(ArmReadCntvCtl)
+GCC_ASM_EXPORT(ArmWriteCntvCtl)
+GCC_ASM_EXPORT(ArmReadCntvCt)
+GCC_ASM_EXPORT(ArmReadCntpCval)
+GCC_ASM_EXPORT(ArmWriteCntpCval)
+GCC_ASM_EXPORT(ArmReadCntvCval)
+GCC_ASM_EXPORT(ArmWriteCntvCval)
+GCC_ASM_EXPORT(ArmReadCntvOff)
+GCC_ASM_EXPORT(ArmWriteCntvOff)
+GCC_ASM_EXPORT(ArmReadCnthpCtl)
+GCC_ASM_EXPORT(ArmWriteCnthpCtl)
+GCC_ASM_EXPORT(ArmReadCnthpTval)
+GCC_ASM_EXPORT(ArmWriteCnthpTval)
+GCC_ASM_EXPORT(ArmReadCnthvCtl)
+GCC_ASM_EXPORT(ArmWriteCnthvCtl)
+GCC_ASM_EXPORT(ArmReadCnthvTval)
+GCC_ASM_EXPORT(ArmWriteCnthvTval)
+
+ASM_PFX(ArmReadCntFrq):
+#  mrs   x0, cntfrq_el0           // Read CNTFRQ
+  ret
+
+
+ASM_PFX(ArmReadCntPct):
+#  mrs   x0, cntpct_el0           // Read CNTPCT (Physical counter register)
+  ret
+
+
+ASM_PFX(ArmReadCntkCtl):
+#  mrs   x0, cntkctl_el1          // Read CNTK_CTL (Timer PL1 Control Register)
+  ret
+
+
+ASM_PFX(ArmWriteCntkCtl):
+#  msr   cntkctl_el1, x0          // Write to CNTK_CTL (Timer PL1 Control Register)
+#  isb
+  ret
+
+
+ASM_PFX(ArmReadCntpTval):
+#  mrs   x0, cntp_tval_el0        // Read CNTP_TVAL (PL1 physical timer value register)
+  ret
+
+
+ASM_PFX(ArmWriteCntpTval):
+#  msr   cntp_tval_el0, x0        // Write to CNTP_TVAL (PL1 physical timer value register)
+#  isb
+  ret
+
+
+ASM_PFX(ArmReadCntpCtl):
+#  mrs   x0, cntp_ctl_el0         // Read CNTP_CTL (PL1 Physical Timer Control Register)
+  ret
+
+
+ASM_PFX(ArmWriteCntpCtl):
+#  msr   cntp_ctl_el0, x0         // Write to  CNTP_CTL (PL1 Physical Timer Control Register)
+#  isb
+  ret
+
+
+ASM_PFX(ArmReadCntvTval):
+#  mrs   x0, cntv_tval_el0        // Read CNTV_TVAL (Virtual Timer Value register)
+  ret
+
+
+ASM_PFX(ArmWriteCntvTval):
+#  msr   cntv_tval_el0, x0        // Write to CNTV_TVAL (Virtual Timer Value register)
+#  isb
+  ret
+
+
+ASM_PFX(ArmReadCntvCtl):
+#  mrs   x0, cntv_ctl_el0         // Read CNTV_CTL (Virtual Timer Control Register)
+  ret
+
+
+ASM_PFX(ArmWriteCntvCtl):
+#  msr   cntv_ctl_el0, x0         // Write to CNTV_CTL (Virtual Timer Control Register)
+#  isb
+  ret
+
+
+ASM_PFX(ArmReadCntvCt):
+#  mrs  x0, cntvct_el0            // Read CNTVCT  (Virtual Count Register)
+  ret
+
+
+ASM_PFX(ArmReadCntpCval):
+#  mrs   x0, cntp_cval_el0        // Read CNTP_CTVAL (Physical Timer Compare Value Register)
+  ret
+
+
+ASM_PFX(ArmWriteCntpCval):
+#  msr   cntp_cval_el0, x0        // Write to CNTP_CTVAL (Physical Timer Compare Value Register)
+#  isb
+  ret
+
+
+ASM_PFX(ArmReadCntvCval):
+#  mrs   x0, cntv_cval_el0        // Read CNTV_CTVAL (Virtual Timer Compare Value Register)
+  ret
+
+
+ASM_PFX(ArmWriteCntvCval):
+#  msr   cntv_cval_el0, x0        // write to  CNTV_CTVAL (Virtual Timer Compare Value Register)
+#  isb
+  ret
+
+
+ASM_PFX(ArmReadCntvOff):
+#  mrs   x0, cntvoff_el2          // Read CNTVOFF (virtual Offset register)
+  ret
+
+
+ASM_PFX(ArmWriteCntvOff):
+#  msr   cntvoff_el2, x0          // Write to CNTVOFF (Virtual Offset register)
+#  isb
+  ret
+
+ASM_PFX(ArmReadCnthpCtl):
+#  mrs   x0, cnthp_ctl_el2
+  ret
+
+
+ASM_PFX(ArmWriteCnthpCtl):
+#  msr   cnthp_ctl_el2, x0
+#  isb
+  ret
+
+ASM_PFX(ArmReadCnthpTval):
+#  mrs   x0, cnthp_tval_el2
+  ret
+
+
+ASM_PFX(ArmWriteCnthpTval):
+#  msr   cnthp_tval_el2, x0
+#  isb
+  ret
+
+ASM_PFX(ArmReadCnthvCtl):
+#  mrs   x0, cnthv_ctl_el2
+  ret
+
+
+ASM_PFX(ArmWriteCnthvCtl):
+#  msr   cnthv_ctl_el2, x0
+#  isb
+  ret
+
+ASM_PFX(ArmReadCnthvTval):
+#  mrs   x0, cnthv_tval_el2
+  ret
+
+
+ASM_PFX(ArmWriteCnthvTval):
+#  msr   cnthv_tval_el2, x0
+#  isb
+  ret
+
+#ifndef TARGET_EMULATION
+ASM_FUNCTION_REMOVE_IF_UNREFERENCED
+#endif

--- a/val/src/RISCV64/GicSupport.S
+++ b/val/src/RISCV64/GicSupport.S
@@ -1,0 +1,101 @@
+#/** @file
+# Copyright (c) 2016-2018,2023 Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#**/
+
+#ifdef TARGET_EMULATION
+/* Private worker functions for ASM_PFX() */
+#define _CONCATENATE(a, b)  __CONCATENATE(a, b)
+#define __CONCATENATE(a, b) a ## b
+
+/* The __USER_LABEL_PREFIX__ macro predefined by GNUC represents
+   the prefix on symbols in assembly language.*/
+#define __USER_LABEL_PREFIX__
+
+#define ASM_PFX(name) _CONCATENATE (__USER_LABEL_PREFIX__, name)
+
+#define GCC_ASM_EXPORT(func__)  \
+       .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)    ;\
+       .type ASM_PFX(func__), %function
+
+#define GCC_ASM_IMPORT(func__)  \
+       .extern  _CONCATENATE (__USER_LABEL_PREFIX__, func__)
+#endif
+
+.text
+.align 2
+
+GCC_ASM_EXPORT(GicReadIchHcr)
+GCC_ASM_EXPORT(GicWriteIchHcr)
+GCC_ASM_EXPORT(GicReadIchMisr)
+GCC_ASM_EXPORT(GicWriteIccIgrpen1)
+GCC_ASM_EXPORT(GicWriteIccBpr1)
+GCC_ASM_EXPORT(GicWriteIccPmr)
+GCC_ASM_EXPORT(GicClearDaif)
+GCC_ASM_EXPORT(GicWriteHcr)
+GCC_ASM_EXPORT(TestExecuteBarrier)
+
+ASM_PFX(GicReadIchHcr):
+  //mrs_s   x0, ich_hcr_el2
+#  .inst 0xd53ccb00
+  ret
+
+ASM_PFX(GicWriteIchHcr):
+  //msr   ich_hcr_el2, x0
+#  .inst 0xd51ccb00
+#  isb
+  ret
+
+ASM_PFX(GicReadIchMisr):
+  //mrs   x0, ich_misr_el2
+#  .inst 0xd53ccb40
+  ret
+
+ASM_PFX(GicWriteIccIgrpen1):
+  //msr   icc_igrpen1_el1, x0
+#  .inst 0xd518cce0
+#  isb
+  ret
+
+ASM_PFX(GicWriteIccBpr1):
+  //msr   icc_brp1_el1, x0
+#  .inst 0xd518cc60
+#  isb
+  ret
+
+ASM_PFX(GicWriteIccPmr):
+  //msr   icc_pmr_el1, x0
+#  .inst 0xd5184600
+#  isb
+  ret
+
+ASM_PFX(GicClearDaif):
+#  msr      daifclr, 0x7
+#  isb
+  ret
+
+ASM_PFX(GicWriteHcr):
+#  msr   hcr_el2, x0
+  ret
+
+ASM_PFX(TestExecuteBarrier):
+#  dsb sy
+#  isb
+  ret
+
+#ifndef TARGET_EMULATION
+ASM_FUNCTION_REMOVE_IF_UNREFERENCED
+#endif

--- a/val/src/RISCV64/PeRegSysSupport.S
+++ b/val/src/RISCV64/PeRegSysSupport.S
@@ -1,0 +1,529 @@
+#/** @file
+# Copyright (c) 2016-2020,2021 Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#**/
+
+//
+// Private worker functions for ASM_PFX()
+//
+#define _CONCATENATE(a, b)  __CONCATENATE(a, b)
+#define __CONCATENATE(a, b) a ## b
+
+#define __USER_LABEL_PREFIX__
+//
+// The __USER_LABEL_PREFIX__ macro predefined by GNUC represents the prefix
+// on symbols in assembly language.
+//
+#define ASM_PFX(name) _CONCATENATE (__USER_LABEL_PREFIX__, name)
+
+#define GCC_ASM_EXPORT(func__)  \
+       .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)    ;\
+       .type ASM_PFX(func__), %function
+
+
+.text
+.align 3
+
+
+GCC_ASM_EXPORT (ArmReadMpidr)
+GCC_ASM_EXPORT (ArmReadIdPfr0)
+GCC_ASM_EXPORT (ArmReadIdPfr1)
+GCC_ASM_EXPORT (AA64ReadMmfr0)
+GCC_ASM_EXPORT (AA64ReadMmfr1)
+GCC_ASM_EXPORT (AA64ReadMmfr2)
+GCC_ASM_EXPORT (AA64ReadCtr)
+GCC_ASM_EXPORT (ArmReadMmfr0)
+GCC_ASM_EXPORT (AA64ReadIsar0)
+GCC_ASM_EXPORT (AA64ReadIsar1)
+GCC_ASM_EXPORT (AA64ReadSctlr3)
+GCC_ASM_EXPORT (AA64ReadSctlr2)
+GCC_ASM_EXPORT (AA64ReadSctlr1)
+GCC_ASM_EXPORT (AA64ReadPmcr)
+GCC_ASM_EXPORT (AA64ReadIdDfr0)
+GCC_ASM_EXPORT (AA64ReadIdDfr1)
+GCC_ASM_EXPORT (ArmReadHcr)
+GCC_ASM_EXPORT (AA64ReadCurrentEL)
+GCC_ASM_EXPORT (AA64ReadIdMdrar)
+GCC_ASM_EXPORT (AA64ReadMdcr2)
+GCC_ASM_EXPORT (AA64WriteMdcr2)
+GCC_ASM_EXPORT (AA64ReadVbar2)
+GCC_ASM_EXPORT (AA64WriteVbar2)
+GCC_ASM_EXPORT (AA64WritePmcr)
+GCC_ASM_EXPORT (AA64WritePmovsset)
+GCC_ASM_EXPORT (AA64WritePmintenset)
+GCC_ASM_EXPORT (AA64WritePmovsclr)
+GCC_ASM_EXPORT (AA64WritePmintenclr)
+GCC_ASM_EXPORT (AA64ReadCcsidr)
+GCC_ASM_EXPORT (AA64ReadCsselr)
+GCC_ASM_EXPORT (AA64WriteCsselr)
+GCC_ASM_EXPORT (AA64ReadClidr)
+GCC_ASM_EXPORT (ArmReadDfr0)
+GCC_ASM_EXPORT (ArmReadIsar0)
+GCC_ASM_EXPORT (ArmReadIsar1)
+GCC_ASM_EXPORT (ArmReadIsar2)
+GCC_ASM_EXPORT (ArmReadIsar3)
+GCC_ASM_EXPORT (ArmReadIsar4)
+GCC_ASM_EXPORT (ArmReadIsar5)
+GCC_ASM_EXPORT (ArmReadMmfr0)
+GCC_ASM_EXPORT (ArmReadMmfr1)
+GCC_ASM_EXPORT (ArmReadMmfr2)
+GCC_ASM_EXPORT (ArmReadMmfr3)
+GCC_ASM_EXPORT (ArmReadMmfr4)
+GCC_ASM_EXPORT (ArmReadPfr0)
+GCC_ASM_EXPORT (ArmReadPfr1)
+GCC_ASM_EXPORT (ArmReadMidr)
+GCC_ASM_EXPORT (ArmReadMvfr0)
+GCC_ASM_EXPORT (ArmReadMvfr1)
+GCC_ASM_EXPORT (ArmReadMvfr2)
+GCC_ASM_EXPORT (AA64ReadPmceid0)
+GCC_ASM_EXPORT (AA64ReadPmceid1)
+GCC_ASM_EXPORT (AA64ReadVmpidr)
+GCC_ASM_EXPORT (AA64ReadVpidr)
+GCC_ASM_EXPORT (AA64ReadPmbidr)
+GCC_ASM_EXPORT (AA64ReadPmsidr)
+GCC_ASM_EXPORT (AA64ReadLorid)
+GCC_ASM_EXPORT (AA64ReadErridr)
+GCC_ASM_EXPORT (AA64ReadErr0fr)
+GCC_ASM_EXPORT (AA64ReadErr1fr)
+GCC_ASM_EXPORT (AA64ReadErr2fr)
+GCC_ASM_EXPORT (AA64ReadErr3fr)
+GCC_ASM_EXPORT (AA64WritePmsirr)
+GCC_ASM_EXPORT (AA64WritePmscr2)
+GCC_ASM_EXPORT (AA64WritePmsfcr)
+GCC_ASM_EXPORT (AA64WritePmbptr)
+GCC_ASM_EXPORT (AA64WritePmblimitr)
+GCC_ASM_EXPORT (AA64ReadEsr2)
+GCC_ASM_EXPORT (AA64ReadSp)
+GCC_ASM_EXPORT (AA64WriteSp)
+GCC_ASM_EXPORT (AA64ReadFar2)
+GCC_ASM_EXPORT (ArmRdvl)
+GCC_ASM_EXPORT (AA64ReadMair1)
+GCC_ASM_EXPORT (AA64ReadMair2)
+GCC_ASM_EXPORT (AA64ReadTcr1)
+GCC_ASM_EXPORT (AA64ReadTcr2)
+GCC_ASM_EXPORT (AA64ReadTtbr0El1)
+GCC_ASM_EXPORT (AA64ReadTtbr0El2)
+GCC_ASM_EXPORT (AA64ReadTtbr1El1)
+GCC_ASM_EXPORT (AA64ReadTtbr1El2)
+GCC_ASM_EXPORT (AA64ReadDbgbcr0El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr1El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr2El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr3El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr4El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr5El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr6El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr7El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr8El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr9El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr10El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr11El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr12El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr13El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr14El1)
+GCC_ASM_EXPORT (AA64ReadDbgbcr15El1)
+
+
+ASM_PFX(ArmReadMpidr):
+#  mrs   x0, mpidr_el1           // read EL1 MPIDR
+  ret
+
+ASM_PFX(ArmReadIdPfr0):
+#  mrs   x0, id_aa64pfr0_el1   // Read ID_AA64PFR0 Register
+  ret
+
+ASM_PFX(ArmReadIdPfr1):
+#  mrs   x0, id_aa64pfr1_el1   // Read ID_AA64PFR0 Register
+  ret
+
+ASM_PFX(AA64ReadMmfr0):
+#  mrs   x0, id_aa64mmfr0_el1
+  ret
+
+ASM_PFX(AA64ReadMmfr1):
+#  mrs   x0, id_aa64mmfr1_el1
+  ret
+
+ASM_PFX(AA64ReadMmfr2):
+#  mrs   x0, id_aa64mmfr2_el1
+  ret
+
+ASM_PFX(AA64ReadCtr):
+#  mrs   x0, ctr_el0
+  ret
+
+ASM_PFX(AA64ReadIsar0):
+#  mrs   x0, id_aa64isar0_el1
+  ret
+
+ASM_PFX(AA64ReadIsar1):
+#  mrs   x0, id_aa64isar1_el1
+  ret
+
+ASM_PFX(AA64ReadSctlr3):
+#  mrs   x0, sctlr_el3
+  ret
+
+ASM_PFX(AA64ReadSctlr2):
+#  mrs   x0, sctlr_el2
+  ret
+
+ASM_PFX(AA64ReadSctlr1):
+#  mrs   x0, sctlr_el1
+  ret
+
+ASM_PFX(AA64ReadPmcr):
+#  mrs   x0, pmcr_el0
+  ret
+
+ASM_PFX(AA64ReadIdDfr0):
+#  mrs   x0, id_aa64dfr0_el1
+  ret
+
+ASM_PFX(AA64ReadIdDfr1):
+#  mrs   x0, id_aa64dfr1_el1
+  ret
+
+// UINTN ArmReadHcr(VOID)
+ASM_PFX(ArmReadHcr):
+#  mrs   x0, hcr_el2
+  ret
+
+ASM_PFX(AA64ReadCurrentEL):
+#  mrs   x0, CurrentEL
+  ret
+
+ASM_PFX(AA64ReadMdcr2):
+#  mrs   x0, mdcr_el2
+  ret
+
+ASM_PFX(AA64WriteMdcr2):
+#  msr   mdcr_el2, x0
+#  isb
+  ret
+
+ASM_PFX(AA64ReadVbar2):
+#  mrs   x0, vbar_el2
+  ret
+
+ASM_PFX(AA64WriteVbar2):
+#  msr   vbar_el2, x0
+#  isb
+  ret
+
+ASM_PFX(AA64WritePmcr):
+#  msr   pmcr_el0, x0
+#  isb
+  ret
+
+ASM_PFX(AA64WritePmovsset):
+#  msr   pmovsset_el0, x0
+#  isb
+  ret
+
+ASM_PFX(AA64WritePmovsclr):
+#  msr   pmovsclr_el0, x0
+#  isb
+  ret
+
+ASM_PFX(AA64WritePmintenset):
+#  msr   pmintenset_el1, x0
+#  isb
+  ret
+
+ASM_PFX(AA64WritePmintenclr):
+#  msr   pmintenclr_el1, x0
+#  isb
+  ret
+
+ASM_PFX(AA64ReadCcsidr):
+#  mrs   x0, ccsidr_el1
+  ret
+
+ASM_PFX(AA64ReadCsselr):
+#  mrs   x0, csselr_el1
+  ret
+
+ASM_PFX(AA64WriteCsselr):
+#  msr   csselr_el1, x0
+#  isb
+  ret
+
+ASM_PFX(AA64ReadClidr):
+#  mrs   x0, clidr_el1
+  ret
+
+ASM_PFX(ArmReadDfr0):
+#  mrs   x0, id_dfr0_el1
+  ret
+
+ASM_PFX(ArmReadIsar0):
+#  mrs   x0, id_isar0_el1
+  ret
+
+ASM_PFX(ArmReadIsar1):
+#  mrs   x0, id_isar1_el1
+  ret
+
+ASM_PFX(ArmReadIsar2):
+#  mrs   x0, id_isar2_el1
+  ret
+
+ASM_PFX(ArmReadIsar3):
+#  mrs   x0, id_isar3_el1
+  ret
+
+ASM_PFX(ArmReadIsar4):
+#  mrs   x0, id_isar4_el1
+  ret
+
+ASM_PFX(ArmReadIsar5):
+#  mrs   x0, id_isar5_el1
+  ret
+
+ASM_PFX(ArmReadMmfr0):
+#  mrs   x0, id_mmfr0_el1
+  ret
+
+ASM_PFX(ArmReadMmfr1):
+#  mrs   x0, id_mmfr1_el1
+  ret
+
+ASM_PFX(ArmReadMmfr2):
+#  mrs   x0, id_mmfr2_el1
+  ret
+
+ASM_PFX(ArmReadMmfr3):
+#  mrs   x0, id_mmfr3_el1
+  ret
+
+ASM_PFX(ArmReadMmfr4):
+  //mrs   x0, id_mmfr4_el1
+  ret
+
+ASM_PFX(ArmReadPfr0):
+#  mrs   x0, id_pfr0_el1
+  ret
+
+ASM_PFX(ArmReadPfr1):
+#  mrs   x0, id_pfr1_el1
+  ret
+
+ASM_PFX(ArmReadMidr):
+#  mrs   x0, midr_el1
+  ret
+
+ASM_PFX(ArmReadMvfr0):
+#  mrs   x0, mvfr0_el1
+  ret
+
+ASM_PFX(ArmReadMvfr1):
+#  mrs   x0, mvfr1_el1
+  ret
+
+ASM_PFX(ArmReadMvfr2):
+#  mrs   x0, mvfr2_el1
+  ret
+
+ASM_PFX(AA64ReadPmceid0):
+#  mrs   x0, pmceid0_el0
+  ret
+
+ASM_PFX(AA64ReadPmceid1):
+#  mrs   x0, pmceid1_el0
+  ret
+
+ASM_PFX(AA64ReadVmpidr):
+#  mrs   x0, vmpidr_el2
+  ret
+
+ASM_PFX(AA64ReadVpidr):
+#  mrs   x0, vpidr_el2
+  ret
+
+ASM_PFX(AA64ReadPmbidr):
+  //mrs   x0, pmbidr_el1
+  ret
+
+ASM_PFX(AA64ReadPmsidr):
+  //mrs   x0, pmsidr_el1
+  ret
+
+ASM_PFX(AA64ReadLorid):
+  //mrs   x0, lorid_el1
+  ret
+
+ASM_PFX(AA64ReadErridr):
+  //mrs   x0, erridr_el1
+  ret
+
+ASM_PFX(AA64ReadErr0fr):
+ // mrs   x0, err0fr_el1
+  ret
+
+ASM_PFX(AA64ReadErr1fr):
+  //mrs   x0, err1fr_el1
+  ret
+
+ASM_PFX(AA64ReadErr2fr):
+  //mrs   x0, err2fr_el1
+  ret
+
+ASM_PFX(AA64ReadErr3fr):
+  //mrs   x0, err3fr_el1
+  ret
+
+ASM_PFX(AA64WritePmsirr):
+  //mrs   pmsirr_el1,x0
+#  isb
+  ret
+
+ASM_PFX(AA64WritePmscr2):
+  //mrs   pmscr_el2,x0
+#  isb
+  ret
+
+ASM_PFX(AA64WritePmsfcr):
+  //mrs   pmsfcr_el1,x0
+#  isb
+  ret
+
+ASM_PFX(AA64WritePmbptr):
+  //mrs   pmbptr_el1,x0
+#  isb
+  ret
+
+ASM_PFX(AA64WritePmblimitr):
+  //mrs   pmblimitr_el1,x0
+#  isb
+  ret
+
+ASM_PFX(AA64ReadEsr2):
+#  mrs   x0, esr_el2
+  ret
+
+ASM_PFX(AA64ReadSp):
+#  mov   x0, sp
+  ret
+
+ASM_PFX(AA64WriteSp):
+#  mov   sp, x0
+  ret
+
+ASM_PFX(AA64ReadFar2):
+#  mrs   x0, far_el2
+  ret
+
+ASM_PFX(AA64ReadMair1):
+#  mrs   x0, mair_el1           // read EL1 MAIR
+  ret
+
+ASM_PFX(AA64ReadMair2):
+#  mrs   x0, mair_el2           // read EL2 MAIR
+  ret
+
+ASM_PFX(AA64ReadTcr1):
+#  mrs   x0, tcr_el1           // read EL1 TCR
+  ret
+
+ASM_PFX(AA64ReadTcr2):
+#  mrs   x0, tcr_el2           // read EL2 TCR
+  ret
+
+ASM_PFX(AA64ReadTtbr0El2):
+#  mrs   x0, ttbr0_el2           // read EL2 TTBR0
+  ret
+
+ASM_PFX(AA64ReadTtbr1El2):
+#  mrs   x0, ttbr1_el2           // read EL2 TTBR1
+  ret
+
+ASM_PFX(AA64ReadTtbr0El1):
+#  mrs   x0, ttbr0_el1           // read EL1 TTBR0
+  ret
+
+ASM_PFX(AA64ReadTtbr1El1):
+#  mrs   x0, ttbr1_el1           // read EL1 TTBR1
+  ret
+
+ASM_PFX(ArmRdvl):
+  //RDVL   x0, #8   // TODO once instruction supports Read Vector Length
+#  .inst 0x04BF5100
+  ret
+
+ ASM_PFX(AA64ReadDbgbcr0El1):
+#  mrs   x0, dbgbcr0_el1          // read EL1 DBGBCR0
+  ret
+
+ASM_PFX(AA64ReadDbgbcr1El1):
+#  mrs   x0, dbgbcr1_el1          // read EL1 DBGBCR1
+  ret
+
+ASM_PFX(AA64ReadDbgbcr2El1):
+#  mrs   x0, dbgbcr2_el1          // read EL1 DBGBCR2
+  ret
+
+ASM_PFX(AA64ReadDbgbcr3El1):
+#  mrs   x0, dbgbcr3_el1          // read EL1 DBGBCR3
+  ret
+
+ASM_PFX(AA64ReadDbgbcr4El1):
+#  mrs   x0, dbgbcr4_el1          // read EL1 DBGBCR4
+  ret
+
+ASM_PFX(AA64ReadDbgbcr5El1):
+#  mrs   x0, dbgbcr5_el1          // read EL1 DBGBCR5
+  ret
+
+ASM_PFX(AA64ReadDbgbcr6El1):
+#  mrs   x0, dbgbcr6_el1          // read EL1 DBGBCR6
+  ret
+
+ASM_PFX(AA64ReadDbgbcr7El1):
+#  mrs   x0, dbgbcr7_el1          // read EL1 DBGBCR7
+  ret
+
+ASM_PFX(AA64ReadDbgbcr8El1):
+#  mrs   x0, dbgbcr8_el1          // read EL1 DBGBCR8
+  ret
+
+ASM_PFX(AA64ReadDbgbcr9El1):
+#  mrs   x0, dbgbcr9_el1          // read EL1 DBGBCR9
+  ret
+
+ASM_PFX(AA64ReadDbgbcr10El1):
+#  mrs   x0, dbgbcr10_el1          // read EL1 DBGBCR10
+  ret
+
+ASM_PFX(AA64ReadDbgbcr11El1):
+#  mrs   x0, dbgbcr11_el1          // read EL1 DBGBCR11
+  ret
+
+ASM_PFX(AA64ReadDbgbcr12El1):
+#  mrs   x0, DBGBCR12_EL1          // read EL1 DBGBCR12
+  ret
+
+ASM_PFX(AA64ReadDbgbcr13El1):
+#  mrs   x0, dbgbcr13_el1          // read EL1 DBGBCR13
+  ret
+
+ASM_PFX(AA64ReadDbgbcr14El1):
+#  mrs   x0, dbgbcr14_el1          // read EL1 DBGBCR14
+  ret
+
+ASM_PFX(AA64ReadDbgbcr15El1):
+#  mrs   x0, dbgbcr15_el1          // read EL1 DBGBCR15
+  ret
+

--- a/val/src/RISCV64/PeTestSupport.S
+++ b/val/src/RISCV64/PeTestSupport.S
@@ -1,0 +1,90 @@
+#/** @file
+# Copyright (c) 2016-2019, 2022-2023 Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#**/
+
+#ifdef TARGET_EMULATION
+/* Private worker functions for ASM_PFX() */
+#define _CONCATENATE(a, b)  __CONCATENATE(a, b)
+#define __CONCATENATE(a, b) a ## b
+
+/* The __USER_LABEL_PREFIX__ macro predefined by GNUC represents
+   the prefix on symbols in assembly language.*/
+#define __USER_LABEL_PREFIX__
+
+#define ASM_PFX(name) _CONCATENATE (__USER_LABEL_PREFIX__, name)
+
+#define GCC_ASM_EXPORT(func__)  \
+       .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)    ;\
+       .type ASM_PFX(func__), %function
+
+#define GCC_ASM_IMPORT(func__)  \
+       .extern  _CONCATENATE (__USER_LABEL_PREFIX__, func__)
+#endif
+
+
+.text
+.align 3
+
+GCC_ASM_EXPORT (ArmCallWFI)
+GCC_ASM_EXPORT (SpeProgramUnderProfiling)
+GCC_ASM_EXPORT (DisableSpe)
+GCC_ASM_EXPORT (ArmExecuteMemoryBarrier)
+
+ASM_PFX(ArmCallWFI):
+#  wfi
+  ret
+
+ASM_PFX(SpeProgramUnderProfiling):
+#  mov   x2,#12    // No of instructions in the loop
+#  udiv  x2,x0,x2  //iteration count = interval/(no of instructions in loop)
+#  add   x2,x2,#6  //add a tolerance above which profiler is guaranteed to generate event
+ASM_PFX(label_if_not_zero):
+ASM_PFX(loop):
+#  ldr   x0,[x1],#8
+#  str   x0,[x1],#8
+#  cmp   x0,#0
+#  bne   ASM_PFX(label_if_not_zero)
+#  ldr   x0,[x1],#8
+#  str   x0,[x1],#8
+#  cmp   x0,#0
+#  bne   ASM_PFX(label_if_not_zero)
+#  ldr   x0,[x1],#8
+#  str   x0,[x1],#8
+#  cmp   x0,#0
+#  bne   ASM_PFX(label_if_not_zero)
+#  sub   x2,x2,#1
+#  cbnz  x2,ASM_PFX(loop)
+  ret
+
+ASM_PFX(DisableSpe):
+#  //mrs   x0,pmscr_el2
+#  bic   x0,x0,#1
+#  //msr   pmscr_el2,x0
+#  isb
+#  //psb   csync
+#  //dci   0xD503223F  // opcode of psb csync
+#  dsb   sy
+#  //mrs   x0,pmblimitr_el1
+#  bic   x0,x0,#1
+#  //msr   pmblimitr_el1,x0
+#  isb
+
+  ret
+
+ASM_PFX(ArmExecuteMemoryBarrier):
+#  dmb sy
+  ret

--- a/val/src/RISCV64/SystemReg.S
+++ b/val/src/RISCV64/SystemReg.S
@@ -1,0 +1,182 @@
+/** @file
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+  .section .text.sysreg, "ax"
+
+    .global val_mair_write
+val_mair_write:
+    cmp        x1, #2
+    b.ne    mair_el1_write
+    msr     mair_el2, x0
+    ret
+
+mair_el1_write:
+    msr     mair_el1, x0
+    ret
+
+    .global val_tcr_write
+val_tcr_write:
+    cmp        x1, #2
+    b.ne    tcr_el1_write
+    msr     tcr_el2, x0
+    tlbi    alle2
+    dsb     sy
+    isb
+    ret
+tcr_el1_write:
+    msr     tcr_el1, x0
+    tlbi     vmalle1
+    dsb      sy
+    isb
+    ret
+
+    .global val_ttbr0_write
+val_ttbr0_write:
+    cmp        x1, #2
+    b.ne    ttbr0_el1_write
+    msr     ttbr0_el2, x0
+    ret
+
+ttbr0_el1_write:
+    msr     ttbr0_el1, x0
+    ret
+
+    .global val_ttbr0_read
+val_ttbr0_read:
+    cmp        x0, #2
+    b.ne    ttbr0_el1_read
+    mrs     x0, ttbr0_el2
+    ret
+ttbr0_el1_read:
+    mrs     x0, ttbr0_el1
+    ret
+
+    .global val_sctlr_read
+val_sctlr_read:
+    cmp        x0, #2
+    b.ne    sctlr_el1_read
+    mrs     x0, sctlr_el2
+    isb
+    ret
+sctlr_el1_read:
+    mrs     x0, sctlr_el1
+    isb
+    ret
+
+    .global val_sctlr_write
+val_sctlr_write:
+    cmp        x1, #2
+    b.ne    sctlr_el1_write
+    msr     sctlr_el2, x0
+    isb
+    ret
+sctlr_el1_write:
+    msr     sctlr_el1, x0
+    isb
+    ret
+
+    .global val_read_current_el
+val_read_current_el:
+    mrs     x0, CurrentEL
+    ret
+
+    .global val_dataCacheCleanInvalidateVA
+val_dataCacheCleanInvalidateVA:
+    dc  civac, x0
+    dsb sy
+    isb
+    ret
+
+    .global val_dataCacheCleanVA
+val_dataCacheCleanVA:
+    dc  cvac, x0
+    dsb ish
+    isb
+    ret
+
+    .global val_dataCacheInvalidateVA
+val_dataCacheInvalidateVA:
+    dc  ivac, x0
+    dsb ish
+    isb
+    ret
+
+.macro    dcache_line_size  reg, tmp
+    mrs    \tmp, ctr_el0
+    ubfx    \tmp, \tmp, #16, #4
+    mov    \reg, #4
+    lsl    \reg, \reg, \tmp
+    .endm
+
+.macro    icache_line_size  reg, tmp
+    mrs    \tmp, ctr_el0
+    and    \tmp, \tmp, #0xf
+    mov    \reg, #4
+    lsl    \reg, \reg, \tmp
+    .endm
+
+.macro do_dcache_maintenance_by_mva op
+    /* Exit early if size is zero */
+    cbz    x1, exit_loop_\op
+    dcache_line_size x2, x3
+    add    x1, x0, x1
+    sub    x3, x2, #1
+    bic    x0, x0, x3
+loop_\op:
+    dc    \op, x0
+    add    x0, x0, x2
+    cmp    x0, x1
+    b.lo    loop_\op
+    dsb    sy
+exit_loop_\op:
+    ret
+.endm
+
+.macro do_icache_maintenance_by_mva op
+    /* Exit early if size is zero */
+    cbz    x1, exit_loop_\op
+    icache_line_size x2, x3
+    add    x1, x0, x1
+    sub    x3, x2, #1
+    bic    x0, x0, x3
+loop_\op:
+    ic    \op, x0
+    add    x0, x0, x2
+    cmp    x0, x1
+    b.lo    loop_\op
+    dsb    sy
+exit_loop_\op:
+    ret
+.endm
+
+    /* ------------------------------------------
+     * Invalidate from base address till
+     * size. 'x0' = addr, 'x1' = size
+     * ------------------------------------------
+     */
+    .global val_inv_dcache_range
+val_inv_dcache_range:
+    do_dcache_maintenance_by_mva ivac
+
+     /* ------------------------------------------
+     * Invalidate from base address till
+     * size. 'x0' = addr, 'x1' = size
+     * ------------------------------------------
+     */
+    .global val_inv_icache_range
+val_inv_icache_range:
+    do_icache_maintenance_by_mva ivau

--- a/val/src/RISCV64/VecTable.S
+++ b/val/src/RISCV64/VecTable.S
@@ -1,0 +1,123 @@
+/** @file
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+  .section .bss.tt, "aw"
+  .align 12
+  .global tt_l0_base
+tt_l0_base:
+  .fill  4096
+
+  .align 12
+  .global tt_l1_base
+tt_l1_base:
+  .fill 4096
+
+  .align 12
+ // Allocate space for 4 contiguous L2 tables
+  .global tt_l2_base_1
+tt_l2_base_1:
+  .fill 16384
+
+  .align 12
+ // Allocate space for 4 contiguous L2 tables
+  .global tt_l2_base_2
+tt_l2_base_2:
+  .fill 16384
+
+  .align 12
+ // Allocate space for 4 contiguous L2 tables
+  .global tt_l2_base_3
+tt_l2_base_3:
+  .fill 16384
+
+  .align 12
+ // Allocate space for 4 contiguous L2 tables
+  .global tt_l2_base_4
+tt_l2_base_4:
+  .fill 16384
+
+  .align 12
+ // Allocate space for 4 contiguous L2 tables
+  .global tt_l2_base_5
+tt_l2_base_5:
+  .fill 16384
+
+  .align 12
+ // Allocate space for 4 contiguous L2 tables
+  .global tt_l2_base_6
+tt_l2_base_6:
+  .fill 16384
+
+   .align 12
+ // Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_1
+tt_l3_base_1:
+  .fill 16384
+
+  .align 12
+// Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_2
+tt_l3_base_2:
+  .fill 16384
+
+  .align 12
+// Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_3
+tt_l3_base_3:
+  .fill 16384
+
+    .align 12
+// Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_4
+tt_l3_base_4:
+  .fill 16384
+
+    .align 12
+// Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_5
+tt_l3_base_5:
+  .fill 16384
+
+    .align 12
+// Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_6
+tt_l3_base_6:
+  .fill 16384
+
+    .align 12
+// Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_7
+tt_l3_base_7:
+  .fill 16384
+
+    .align 12
+// Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_8
+tt_l3_base_8:
+  .fill 16384
+
+    .align 12
+// Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_9
+tt_l3_base_9:
+  .fill 16384
+
+    .align 12
+// Allocate space for 6 contiguous L3 tables
+  .global tt_l3_base_10
+tt_l3_base_10:
+  .fill 16384

--- a/val/sys_arch_src/gic/RISCV64/bsa_exception_asm.S
+++ b/val/sys_arch_src/gic/RISCV64/bsa_exception_asm.S
@@ -1,0 +1,315 @@
+/** @file
+ * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#ifndef TARGET_EMULATION
+#include "include/bsa_acs_pe.h"
+#include "sys_arch_src/gic/bsa_exception.h"
+#else
+#define EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS    0
+#define EXCEPT_AARCH64_IRQ                       1
+#define EXCEPT_AARCH64_FIQ                       2
+#define EXCEPT_AARCH64_SERROR                    3
+#endif
+
+/* Private worker functions for ASM_PFX() */
+#define _CONCATENATE(a, b)  __CONCATENATE(a, b)
+#define __CONCATENATE(a, b) a ## b
+
+/* The __USER_LABEL_PREFIX__ macro predefined by GNUC represents
+   the prefix on symbols in assembly language.*/
+#define __USER_LABEL_PREFIX__
+
+#define ASM_PFX(name) _CONCATENATE (__USER_LABEL_PREFIX__, name)
+
+#define GCC_ASM_EXPORT(func__)  \
+       .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)    ;\
+       .type ASM_PFX(func__), %function
+
+#define GCC_ASM_IMPORT(func__)  \
+       .extern  _CONCATENATE (__USER_LABEL_PREFIX__, func__)
+
+GCC_ASM_IMPORT(common_exception_handler)
+GCC_ASM_EXPORT(bsa_gic_set_el2_vector_table)
+GCC_ASM_EXPORT(bsa_gic_update_elr)
+GCC_ASM_EXPORT(bsa_gic_get_far)
+GCC_ASM_EXPORT(bsa_gic_get_esr)
+GCC_ASM_EXPORT(bsa_gic_get_elr)
+
+
+#define CHECK_EL_1_OR_2_OR_3(REG) \
+#        mrs    REG, CurrentEL ;\
+#        cmp    REG, #0x8      ;\
+#        b.gt   3f             ;\
+#        b.eq   2f             ;\
+#        cbnz   REG, 1f        ;\
+#        b      .              ;// We should never get here
+
+/**
+ * This is a generic handler for exceptions taken at the current EL while using
+ * SPx. It saves volatile registers, calls the C handler, restores volatile
+ * registers, then returns.
+ *
+ * Saving state and jumping to C handler takes 15 instructions. We add an extra
+ * branch to a common exit path. So each handler takes up one unique cache line
+ * and one shared cache line (assuming 16-byte cache lines).
+ */
+.macro current_exception_spx elx:req handler:req
+#    save_volatile_to_stack \elx
+#    bl \handler
+#    b restore_from_stack_and_return
+.endm
+
+.macro current_el_with_spx elx:req val:req
+#    save_volatile_to_stack \elx
+#    mov x0, #\val
+#    bl  ASM_PFX(common_exception_handler)
+#    b restore_from_stack_and_return
+.endm
+
+/**
+ * Saves the volatile registers onto the stack. This currently takes 14
+ * instructions, so it can be used in exception handlers with 18 instructions
+ * left, 2 of which in the same cache line (assuming a 16-byte cache line).
+ *
+ * On return, x0 and x1 are initialised to elr_el2 and spsr_el2 respectively,
+ * which can be used as the first and second arguments of a subsequent call.
+ */
+.macro save_volatile_to_stack elx:req
+#     /* Reserve stack space and save registers x0-x18, x29 & x30. */
+#     stp x0, x1, [sp, #-(8 * 24)]!
+#     stp x2, x3, [sp, #8 * 2]
+#     stp x4, x5, [sp, #8 * 4]
+#     stp x6, x7, [sp, #8 * 6]
+#     stp x8, x9, [sp, #8 * 8]
+#     stp x10, x11, [sp, #8 * 10]
+#     stp x12, x13, [sp, #8 * 12]
+#     stp x14, x15, [sp, #8 * 14]
+#     stp x16, x17, [sp, #8 * 16]
+#     str x18, [sp, #8 * 18]
+#     stp x29, x30, [sp, #8 * 20]
+# 
+#     /*
+#      * Save elr_elx & spsr_elx. This such that we can take nested exception
+#      * and still be able to unwind.
+#      */
+#     CHECK_EL_1_OR_2_OR_3(x0)
+# 1:  mrs   x0, elr_el1
+#     mrs   x1, spsr_el1
+#     b     4f
+# 2:  mrs   x0, elr_el2
+#     mrs   x1, spsr_el2
+#     b     4f
+# 3:  mrs   x0, elr_el3
+#     mrs   x1, spsr_el3
+# 4:  stp x0, x1, [sp, #8 * 22]
+
+.endm
+
+  .section .text.vtable, "ax"
+  .align 12
+
+.global vector_table
+vector_table:
+
+// ------------------------------------------------------------
+// Current EL with SP0
+// ------------------------------------------------------------
+  .balign 128
+sync_current_el_sp0:
+  current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+irq_current_el_sp0:
+  current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+fiq_current_el_sp0:
+  current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+serror_current_el_sp0:
+  current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+// ------------------------------------------------------------
+// Current EL with SPx
+// ------------------------------------------------------------
+
+  .balign 128
+sync_current_el_spx:
+  current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+irq_current_el_spx:
+  current_el_with_spx el2 EXCEPT_AARCH64_IRQ
+
+  .balign 128
+fiq_current_el_spx:
+  current_el_with_spx el2 EXCEPT_AARCH64_FIQ
+
+  .balign 128
+serror_current_el_spx:
+  current_el_with_spx el2 EXCEPT_AARCH64_SERROR
+
+// ------------------------------------------------------------
+// Lower EL using AArch64
+// ------------------------------------------------------------
+
+  .balign 128
+sync_lower_el_aarch64:
+#  B        .                   //       Synchronous exception
+  //current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+irq_lower_el_aarch64:
+#  B        .                    //        IRQ
+  //current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+fiq_lower_el_aarch64:
+#  B        .                    //        FIQ
+  //current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+serror_lower_el_aarch64:
+#  B        .                    //        SError
+  //current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+// ------------------------------------------------------------
+// Lower EL using AArch32
+// ------------------------------------------------------------
+
+  .balign 128
+sync_lower_el_aarch32:
+#  B        .
+  //current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+irq_lower_el_aarch32:
+#  B        .                    //        IRQ
+  //current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+fiq_lower_el_aarch32:
+#  B        .                    //        FIQ
+  //current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+  .balign 128
+serror_lower_el_aarch32:
+#  B        .                    //        SError
+  //current_el_with_spx el2 EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+
+.balign 0x40
+/**
+ * Restores the volatile registers from the stack.
+
+ * Register x0: if false restores elr_el2, if true retains the value of elr_el2.
+ * This enables exception handlers to indicate whether they have changed the
+ * value of elr_el2 (e.g., to skip the faulting instruction).
+ */
+restore_from_stack_and_return:
+#    /* Restore registers x2-x18, x29 & x30. */
+#    ldp x2, x3, [sp, #8 * 2]
+#    ldp x4, x5, [sp, #8 * 4]
+#    ldp x6, x7, [sp, #8 * 6]
+#    ldp x8, x9, [sp, #8 * 8]
+#    ldp x10, x11, [sp, #8 * 10]
+#    ldp x12, x13, [sp, #8 * 12]
+#    ldp x14, x15, [sp, #8 * 14]
+#    ldp x16, x17, [sp, #8 * 16]
+#    ldr x18, [sp, #8 * 18]
+#    ldp x29, x30, [sp, #8 * 20]
+#
+#    cbnz x0, skip_elr
+#
+#    /* Restore register elr_el2 using x1 as scratch. */
+#    ldr x1, [sp, #8 * 22]
+#    CHECK_EL_1_OR_2_OR_3(x0)
+#1:  msr   elr_el1, x1
+#    b     4f
+#2:  msr   elr_el2, x1
+#    b     4f
+#3:  msr   elr_el3, x1
+#4:  isb
+
+skip_elr:
+#    /* Restore register spsr_el2 using x1 as scratch. */
+#    ldr x1, [sp, #8 * 23]
+#    CHECK_EL_1_OR_2_OR_3(x0)
+#1:  msr   spsr_el1, x1
+#    b     4f
+#2:  msr   spsr_el2, x1
+#    b     4f
+#3:  msr   spsr_el3, x1
+#4:  isb
+#
+#    /* Restore x0 & x1, and release stack space. */
+#    ldp x0, x1, [sp], #8 * 24
+#
+#    eret
+
+
+// ------------------------------------------------------------
+// Set Vector Table
+// ------------------------------------------------------------
+
+ASM_PFX(bsa_gic_set_el2_vector_table):
+#    adr x0, vector_table
+#    CHECK_EL_1_OR_2_OR_3(x1)
+#1:  msr   vbar_el1, x0
+#    b     4f
+#2:  msr   vbar_el2, x0
+#    b     4f
+#3:  msr   vbar_el3, x0
+#4:  isb
+    ret
+
+ASM_PFX(bsa_gic_update_elr):
+#    CHECK_EL_1_OR_2_OR_3(x1)
+#1:  msr   elr_el1, x0
+#    b     4f
+#2:  msr   elr_el2, x0
+#    b     4f
+#3:  msr   elr_el3, x0
+#4:  isb
+    ret
+
+ASM_PFX(bsa_gic_get_elr):
+#    CHECK_EL_1_OR_2_OR_3(x1)
+#1:  mrs   x0, elr_el1
+#    b     4f
+#2:  mrs   x0, elr_el2
+#    b     4f
+#3:  mrs   x0, elr_el3
+4:  ret
+
+ASM_PFX(bsa_gic_get_esr):
+#    CHECK_EL_1_OR_2_OR_3(x1)
+#1:  mrs   x0, esr_el1
+#    b     4f
+#2:  mrs   x0, esr_el2
+#    b     4f
+#3:  mrs   x0, esr_el3
+4:  ret
+
+ASM_PFX(bsa_gic_get_far):
+#    CHECK_EL_1_OR_2_OR_3(x1)
+#1:  mrs   x0, far_el1
+#    b     4f
+#2:  mrs   x0, far_el2
+#    b     4f
+#3:  mrs   x0, far_el3
+4:  ret

--- a/val/sys_arch_src/gic/v3/RISCV64/v3_asm.S
+++ b/val/sys_arch_src/gic/v3/RISCV64/v3_asm.S
@@ -1,0 +1,51 @@
+/** @file
+ * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#ifndef TARGET_EMULATION
+#include "include/bsa_acs_pe.h"
+#include "sys_arch_src/gic/bsa_exception.h"
+#else
+#define ICC_IAR1_EL1    S3_0_C12_C12_0
+#define ICC_EOIR1_EL1   S3_0_C12_C12_1
+#endif
+
+
+/* Private worker functions for ASM_PFX() */
+#define _CONCATENATE(a, b)  __CONCATENATE(a, b)
+#define __CONCATENATE(a, b) a ## b
+
+/* The __USER_LABEL_PREFIX__ macro predefined by GNUC represents
+   the prefix on symbols in assembly language.*/
+#define __USER_LABEL_PREFIX__
+
+#define ASM_PFX(name) _CONCATENATE (__USER_LABEL_PREFIX__, name)
+
+#define GCC_ASM_EXPORT(func__)  \
+       .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)    ;\
+       .type ASM_PFX(func__), %function
+
+GCC_ASM_EXPORT(bsa_gic_ack_intr)
+GCC_ASM_EXPORT(bsa_gic_end_intr)
+
+
+ASM_PFX(bsa_gic_ack_intr):
+#   mrs x0, ICC_IAR1_EL1
+   ret
+
+ASM_PFX(bsa_gic_end_intr):
+#   msr ICC_EOIR1_EL1, x0
+   ret


### PR DESCRIPTION
Basic Init RISCV64 tool chain. (for Ubuntu20.04 default riscv-gcc)
